### PR TITLE
添加 SNAP 包构建到 Github Action CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -414,6 +414,69 @@ jobs:
           path: '*-aarch64.pkg.*'
           if-no-files-found: error
 
+  pack-snap-x86_64:
+    runs-on: ubuntu-latest
+    needs: build-x86_64
+    defaults:
+      run:
+        working-directory: icalingua
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.3.0
+
+      - uses: Clansty/gha-yarn-node-cache@master
+        env:
+          WORKING_DIR: icalingua
+
+      - name: get built files
+        uses: actions/download-artifact@v2
+        with:
+          name: x86_64-unpacked
+          path: icalingua/unpacked
+
+      - name: fix premissions
+        run: chmod +x unpacked/icalingua
+
+      - name: Install Snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+          sudo snap install lxd
+          sudo usermod --append --groups lxd $USER
+          sudo chown root:root /
+          sudo /snap/bin/lxd waitready
+          sudo /snap/bin/lxd init --auto
+          newgrp
+
+      - name: pack
+        id: pack
+        run: |
+          sg lxd -c 'yarn build:electron --pd unpacked -l snap -p never'
+          echo "::set-output name=snap::$(readlink -f $(ls build/*.snap))"
+        env:
+          SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+
+      - uses: actions/upload-artifact@v2
+        name: upload snap
+        with:
+          name: x86_64.snap
+          path: icalingua/build/*.snap
+          if-no-files-found: error
+
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAP_TOKEN }}
+          snap: ${{ steps.pack.outputs.snap }}
+          release: edge
+
+      - uses: snapcore/action-publish@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          store_login: ${{ secrets.SNAP_TOKEN }}
+          snap: ${{ steps.pack.outputs.snap }}
+          release: stable
+
   pack-otherpkg-x86_64:
     runs-on: ubuntu-latest
     needs: build-x86_64
@@ -623,6 +686,7 @@ jobs:
       - pack-archpkg-x86_64
       - pack-archpkg-i686
       - pack-archpkg-aarch64
+      - pack-snap-x86_64
       - pack-otherpkg-x86_64
       - pack-otherpkg-ia32
       - pack-otherpkg-arm64
@@ -722,6 +786,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: x86_64.AppImage
+          path: release
+
+      - name: get x86_64.snap
+        uses: actions/download-artifact@v2
+        with:
+          name: x86_64.snap
           path: release
 
       - name: get x86_64.tar.xz

--- a/icalingua/package.json
+++ b/icalingua/package.json
@@ -43,10 +43,26 @@
         },
         {
           "target": "AppImage"
+        },
+        {
+          "target": "snap"
         }
       ],
       "executableName": "icalingua",
       "category": "Network"
+    },
+    "snap": {
+      "summary": "A Linux IM client for QQ and more",
+      "environment": {
+        "HOME": "$SNAP_REAL_HOME",
+        "XDG_CONFIG_HOME": "$SNAP_USER_DATA/.config",
+        "XDG_CACHE_HOME": "$SNAP_USER_DATA/.cache",
+        "XDG_DATA_HOME": "$SNAP_USER_DATA/.local/share"
+      },
+      "stagePackages": [
+        "default",
+        "ffmpeg"
+      ]
     },
     "npmRebuild": false
   },


### PR DESCRIPTION
* 创建 'pack-snap-x86_64' 环节用以打包 SNAP
* on push: 将 snap 打包结果发布到 Snap 商店的 'edge' 频道;
* on tag: 将 snap 打包结果发布到 Snap 商店的 'stable' 频道;

Signed-off-by: Tao Wang <twang2218@gmail.com>