### PR TITLE
F:修复部分用户头像显示不正确

### DIFF
--- a/icalingua/src/utils/getAvatarUrl.ts
+++ b/icalingua/src/utils/getAvatarUrl.ts
@@ -3,5 +3,5 @@ let timestamp = new Date().getTime()
 export default (roomId: number, cache = false): string => {
     return (roomId < 0)
         ? `https://p.qlogo.cn/gh/${-roomId}/${-roomId}/0` + (cache ? '' : `?timestamp=${timestamp}`)
-        : `https://q1.qlogo.cn/g?b=qq&nk=${roomId}&s=640` + (cache ? '' : `&timestamp=${timestamp}`)
+        : `https://q1.qlogo.cn/g?b=qq&nk=${roomId}&s=140` + (cache ? '' : `&timestamp=${timestamp}`)
 }


### PR DESCRIPTION
### 原因
有些账号多年不曾更换头像，请求640x640大小头像，将直接返回默认的企鹅头像

### 处理
改为请求 140x140 大小头像

### 影响
对于某些需要用到用户头像的场景，头像清晰度可能降低
