### PR TITLE
F:修复 emoji 面板溢出

### DIFF
--- a/icalingua/src/renderer/components/Stickers.vue
+++ b/icalingua/src/renderer/components/Stickers.vue
@@ -55,7 +55,7 @@
                 </div>
             </div>
         </div>
-        <div v-show="panel === 'emojis'">
+        <div class="emoji-panel" v-show="panel === 'emojis'">
             <VEmojiPicker @select="$emit('selectEmoji', $event)"/>
         </div>
     </div>
@@ -232,6 +232,31 @@ div.head {
   }
 }
 
+
+// 修复 emoji 面板溢出
+@mixin emoji-flex {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.emoji-panel {
+    @include emoji-flex;
+}
+
+::v-deep #Emojis {
+    @include emoji-flex;
+    display: flex !important;
+}
+
+::v-deep #Categories,::v-deep #InputSearch {
+    flex-shrink: 0;
+}
+
+::v-deep .container-emoji {
+    height: auto !important;;
+}
+
 </style>
 
 <style scoped>
@@ -244,7 +269,4 @@ div.head {
   border: none !important;
 }
 
-::v-deep .container-emoji {
-  height: calc(100vh - 147px) !important;
-}
 </style>


### PR DESCRIPTION
### 问题
Emoji 选择面板溢出，详见 #333 

### 发生原因
emoji 容器元素高度过高

### 解决方案
使用 flex 布局，自动缩放 emoji 面板，面板内部仅让 emoji 容器进行自动缩放

### 影响
修改了 v-emoji-picker 内部元素样式，后续可能由前者变动产生影响

