### PR TITLE
F: 修复最近消息的一些问题

### DIFF
--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -1237,7 +1237,9 @@ const adapter: OicqAdapter = {
                         messages.push(message)
                         newMsgs.push(message)
                         console.log(retData)
-                        lastMessage = retData.message
+                        lastMessage = Object.assign(retData.message,retData.lastMessage,{
+                            username: getUin() == retData.message.senderId ? "You": retData.message.username
+                        }) 
                     } catch (e) {
                         errorHandler(e, true)
                     }

--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -1279,6 +1279,8 @@ const adapter: OicqAdapter = {
             }
         }
 
+        // 更新最近消息
+        if (!messages.length) return
         let room = await storage.getRoom(roomId)
         room.lastMessage = lastMessage
         ui.updateRoom(room)

--- a/icalingua/src/main/utils/processMessage.ts
+++ b/icalingua/src/main/utils/processMessage.ts
@@ -14,6 +14,9 @@ import getImageUrlByMd5 from '../../utils/getImageUrlByMd5'
 const processMessage = async (oicqMessage: MessageElem[], message: Message, lastMessage: LastMessage, roomId = null) => {
     if (!Array.isArray(oicqMessage))
         oicqMessage = [oicqMessage]
+    
+    lastMessage.content = lastMessage.content ?? "" // 初始化最近信息内容
+
     let lastType
     for (let i = 0; i < oicqMessage.length; i++) {
         const m = oicqMessage[i]

--- a/icalingua/src/renderer/components/multipane/multipane.ts
+++ b/icalingua/src/renderer/components/multipane/multipane.ts
@@ -37,7 +37,7 @@ export default {
 
   methods: {
     onMouseDown({ target: resizer, pageX: initialPageX, pageY: initialPageY }) {
-      if (resizer.className && resizer.className.match('multipane-resizer')) {
+      if (typeof resizer.className === 'string' && resizer.className.match('multipane-resizer')) {
         const resizeNext = resizer.className.match('resize-next')
         let self = this;
         let { $el: container, layout } = self;


### PR DESCRIPTION
修复内容在界面表现形式为 #326 

详细问题分为以下几点：
1. 最近消息内容未初始化，终端日志表现为「最近消息内容最前面为`undefined`字符」
2. 获取0条历史消息也对最近消息进行更新
3. 获取历史信息最近消息格式与发送信息后不一致，如只显示文本内容
4. 界面点击非DOM元素，终端抛出`match`非函数错误，（与#326无关）
