### PR TITLE
F:修复联系人面板背景色

### DIFF
--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -115,6 +115,7 @@
             title="联系人"
             :visible.sync="contactsShown"
             top="5vh"
+            class="dialog"
         >
             <TheContactsPanel
                 @dblclick="startChat"
@@ -570,5 +571,13 @@ main div {
       -webkit-appearance: none;
     }
   }
+}
+
+.dialog .el-dialog__body,.el-dialog__header {
+  background-color: var(--panel-background);
+}
+
+.dialog .el-dialog__title {
+  color: var(--panel-color-name);
 }
 </style>


### PR DESCRIPTION
Fixes #323 
把.el-dialog的背景颜色改为panel.background，.el-dialog__title的文字颜色改为panel.colorName，适配亮色和暗色主题
（要不要在主题里单独开一个dialog样式？）
![image](https://user-images.githubusercontent.com/54884471/144175422-974ba2df-f88e-41c0-9d59-3a9d3d60ddbd.png)
