### PR TITLE
增加 Windows 安装包构建到 Github Action CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,0 +1,76 @@
+name: Windows CI
+
+on:
+  - push
+  - workflow_dispatch
+
+jobs:
+  install:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: icalingua
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: Clansty/gha-yarn-node-cache@master
+        env:
+          WORKING_DIR: icalingua
+      - name: npm install
+        run: npm install
+
+  build:
+
+    runs-on: windows-latest
+    needs: install
+    outputs:
+      version: ${{ steps.git-ver.outputs.version }}
+      arch-version: ${{ steps.version.outputs.arch-version }}
+      pkg-name: ${{ steps.version.outputs.pkg-name }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - uses: Clansty/gha-yarn-node-cache@master
+      env:
+        WORKING_DIR: icalingua
+        
+    - id: git-ver
+      run: echo "::set-output name=version::$(git describe --tags | sed 's/v//')"
+      
+    - name: check version and write version info
+      run: node .github/check-version.js
+      id: version
+      env:
+        SHA: ${{ github.sha }}
+        REF: ${{ github.REF }}
+        GIT_VER: ${{ steps.git-ver.outputs.version }}
+        
+    - name: build
+      run: npm run build
+      working-directory: icalingua
+      
+    - uses: actions/upload-artifact@v2
+      name: upload Icalingua Setup
+      with:
+        name: Icalingua_Setup_Windows.exe
+        path: icalingua/build/Icalingua Setup *.exe
+        if-no-files-found: error
+    - name: Release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: icalingua/build/Icalingua Setup *.exe


### PR DESCRIPTION
增加构建Windows版Icalingua的workflow
某个酷安群群友希望能够有Windows版本
<del>引用群友的一句话：electron的目的就是跨平台，既然用了Electron为什么不构建Windows版？</del>